### PR TITLE
Null view parts

### DIFF
--- a/lib/rodakase/view/layout.rb
+++ b/lib/rodakase/view/layout.rb
@@ -88,15 +88,14 @@ module Rodakase
       end
 
       def template_part(name, value)
-        if value
-          part(template_path, name => value)
-        else
-          NullPart.new
-        end
+        part(template_path, name => value)
       end
 
       def part(dir, value)
-        Part.new(renderer.chdir(dir), value)
+        value_present = value.values.first
+        part_class = value_present ? Part : NullPart
+
+        part_class.new(renderer.chdir(dir), value)
       end
     end
   end

--- a/lib/rodakase/view/layout.rb
+++ b/lib/rodakase/view/layout.rb
@@ -2,6 +2,7 @@ require 'dry-configurable'
 require 'dry-equalizer'
 
 require 'rodakase/view/part'
+require 'rodakase/view/null_part'
 require 'rodakase/view/renderer'
 
 module Rodakase
@@ -87,7 +88,11 @@ module Rodakase
       end
 
       def template_part(name, value)
-        part(template_path, name => value)
+        if value
+          part(template_path, name => value)
+        else
+          NullPart.new
+        end
       end
 
       def part(dir, value)

--- a/lib/rodakase/view/null_part.rb
+++ b/lib/rodakase/view/null_part.rb
@@ -2,13 +2,9 @@ require 'dry-equalizer'
 
 module Rodakase
   module View
-    class NullPart
+    class NullPart < Part
       def [](key);end
       def each(&block);end
-
-      def render(path, &block)
-        ''
-      end
 
       def respond_to_missing?(meth, include_private = false)
         true
@@ -17,7 +13,13 @@ module Rodakase
       private
 
       def method_missing(meth, *args, &block)
-        nil
+        template_path = template?("#{meth}_missing")
+
+        if template_path
+          render(template_path)
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/rodakase/view/null_part.rb
+++ b/lib/rodakase/view/null_part.rb
@@ -1,0 +1,25 @@
+require 'dry-equalizer'
+
+module Rodakase
+  module View
+    class NullPart
+      def bind(&block);end
+      def [](key);end
+      def each(&block);end
+
+      def render(path, &block)
+        ''
+      end
+
+      def respond_to_missing?(meth, include_private = false)
+        true
+      end
+
+      private
+
+      def method_missing(meth, *args, &block)
+        nil
+      end
+    end
+  end
+end

--- a/lib/rodakase/view/null_part.rb
+++ b/lib/rodakase/view/null_part.rb
@@ -3,7 +3,6 @@ require 'dry-equalizer'
 module Rodakase
   module View
     class NullPart
-      def bind(&block);end
       def [](key);end
       def each(&block);end
 

--- a/lib/rodakase/view/part.rb
+++ b/lib/rodakase/view/part.rb
@@ -13,6 +13,10 @@ module Rodakase
         @_value = data.values[0]
       end
 
+      def bind(&block)
+        yield(_value)
+      end
+
       def [](key)
         _value[key]
       end

--- a/lib/rodakase/view/part.rb
+++ b/lib/rodakase/view/part.rb
@@ -13,10 +13,6 @@ module Rodakase
         @_value = data.values[0]
       end
 
-      def bind(&block)
-        yield(_value)
-      end
-
       def [](key)
         _value[key]
       end

--- a/spec/unit/view/layout_spec.rb
+++ b/spec/unit/view/layout_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Rodakase::View::Layout do
       expect(part[:name]).to eql('Jane')
     end
 
+    it 'builds null parts for nil values' do
+      part = layout.parts(user: nil)
+
+      expect(part[:id]).to be_nil
+    end
+
     it 'returns default scope when empty locals are passed' do
       expect(layout.parts({})).to be(layout.class::DEFAULT_SCOPE)
     end

--- a/spec/unit/view/null_part_spec.rb
+++ b/spec/unit/view/null_part_spec.rb
@@ -1,0 +1,39 @@
+require 'rodakase/view/null_part'
+
+RSpec.describe Rodakase::View::NullPart do
+  subject(:part) do
+    Rodakase::View::NullPart.new(renderer, data)
+  end
+
+  let(:name) { :user }
+  let(:data) { { user: nil } }
+
+  let(:renderer) { double(:renderer) }
+
+  describe '#[]' do
+    it 'returns nil for any data value names' do
+      expect(part[:email]).to eql(nil)
+    end
+  end
+
+  describe '#method_missing' do
+    it 'renders a template with the _missing suffix' do
+      expect(renderer).to receive(:lookup).with('_row_missing').and_return('_row_missing.slim')
+      expect(renderer).to receive(:render).with('_row_missing.slim', part)
+
+      part.row
+    end
+
+    it 'renders a _missing template within another when block is passed' do
+      block = proc { part.fields }
+
+      expect(renderer).to receive(:lookup).with('_form_missing').and_return('form_missing.slim')
+      expect(renderer).to receive(:lookup).with('_fields_missing').and_return('fields_missing.slim')
+
+      expect(renderer).to receive(:render).with('form_missing.slim', part, &block)
+      expect(renderer).to receive(:render).with('fields_missing.slim', part)
+
+      part.form(block)
+    end
+  end
+end


### PR DESCRIPTION
This makes it easier for a Rodakase application developer to work with `nil` locals in a view. Previously, the following things were problematic:

* It wasn't possible to do a normal truthiness checks (e.g. `- if my_local`) in the template to determine whether or not to render blocks of content, because `my_local` is actually a `Rodakase::View::Part`, which is always truthy. The temporary workaround to this would be to use `- if my_local._value`, which is awful :wink: 
* Trying to call the methods that would exist on the non-nil form of the local would raise an exception (e.g. `my_local.some_method`).
* Rendering a partial that expects the local to be non-nil will similarly raise an exception if that partial expected the local to be a real non-nil value (e.g. `my_local.some_partial_name`).

This PR addresses these problems by wrapping nil view locals in `Rodakase::View::NullPart` objects. Null parts do the following:

* Ordinary method calls or property accesses on the object become no-ops, all just returning `nil`.
* Method calls that correspond to partial names will not render the partial. 
* Method calls will look for a corresponding partial name with the `_missing` suffix and render that partial if it exists (e.g. `my_local.some_partial_name` will look for and render a `_some_partial_name_missing.slim` template if it exists). Doing this will also encourage template developers to use partials more than just big `if` statements in their templates (since that's still not really possible with Rodakase view parts).

Together, this means we could have a template like this (n.b. this is a contrived example, but please bear with me) that works very nicely with both present and missing locals:

```slim
/ This corresponds to a partial, which will only render if errors is non-nil
= errors.errors_explanation

form
  / The no-op method calls means that we can still safely use them inline like this
  input type="text" name="post[title]" value=post.title
  input type="submit" value="Save"
```

This template will still render nicely even if both `errors` and `post` were nil! And having the "_missing" fallback for partial rendering means that template authors are discouraged from having lots of conditionals in their templates too.

What do you think, @solnic?

I've switched our own applications across to this branch of rodakase so we can start improving our templates along these lines, since I think _something_ like this will eventually be needed.