### PR TITLE
Allow direct output of string-convertible view locals in templates

### DIFF
--- a/lib/rodakase/view/part.rb
+++ b/lib/rodakase/view/part.rb
@@ -13,6 +13,10 @@ module Rodakase
         @_value = data.values[0]
       end
 
+      def to_s
+        _value.to_s
+      end
+
       def [](key)
         _value[key]
       end

--- a/spec/fixtures/templates/users.slim
+++ b/spec/fixtures/templates/users.slim
@@ -1,3 +1,5 @@
+h2 = subtitle
+
 .users
   == users.index_table do
     == users.tbody

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'Rodakase View' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: { users: users })).to eql(
-      '<!DOCTYPE html><html><head><title>Rodakase Rocks!</title></head><body><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    expect(view.(scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
+      '<!DOCTYPE html><html><head><title>Rodakase Rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
 


### PR DESCRIPTION
This PR makes it easier to work with "string-convertible" values (e.g. strings or integers, etc.) as view locals.

Previously, if you had something like this as the view locals:

```ruby
{title: "Hi there"}
```

And a template like this:

```slim
= title
```

The output of the template would be the same as running `#inspect` on that `Rodakase::View::Part` object, which didn't seem ideal.

Adding `#to_s` to `Part` and delegating it to the part's value makes it easier to work with these types of values in the views.